### PR TITLE
feat(user): add ability for users to register to the platform

### DIFF
--- a/src/backend/__tests__/user.test.js
+++ b/src/backend/__tests__/user.test.js
@@ -30,7 +30,7 @@ describe('User', () => {
       .then((response) => {
         // assign reponse object to globally available resBody
         // for use in assertions
-        resBody = response;
+        resBody = response.data;
 
         done();
       })
@@ -41,7 +41,7 @@ describe('User', () => {
 
 
   // POST /users (register new user)
-  test('user can register', () => {
+  test.only('user can register', () => {
     // this expects global var resBody to have success message
     expect(resBody.message).toBe('user successfully created');
   });
@@ -54,9 +54,9 @@ describe('User', () => {
       axios
         .post('/login', userData)
         .then((response) => {
-          token = response.token; // set global var token
+          token = response.data.token; // set global var token
 
-          authUserId = response.id; // logged in user _id for jwt auth purposes
+          authUserId = response.data.id; // logged in user _id for jwt auth purposes
 
           done();
         })
@@ -91,7 +91,7 @@ describe('User', () => {
         )
         .then((response) => {
           // then there details are updated in db
-          expect(response.message).toBe('user successfully updated');
+          expect(response.data.message).toBe('user successfully updated');
 
           done();
         })
@@ -123,7 +123,7 @@ describe('User', () => {
         )
         .then((response) => {
           // then their account gets deleted
-          expect(response.message).toBe('user successfully deleted');
+          expect(response.data.message).toBe('user successfully deleted');
 
           done();
         })

--- a/src/backend/controllers/user.js
+++ b/src/backend/controllers/user.js
@@ -1,11 +1,38 @@
 
-const logger = require('../utils/winston');
+const bcrypt = require('bcrypt');
 
-exports.testEndpoint = async (req, res, next) => {
-  try {
-    res.status(200).json({ test: 'OK' });
-    logger.debug('This was a test');
-  } catch (error) {
-    next(error); // this will go to the error handler in app.js e.g. if there's a db error above
-  }
+const User = require('../models/User');
+
+const signup = (req, res, next) => {
+  const { email, username, password } = req.body; // user attributes from request body
+
+  bcrypt
+    .hash(password, 10)
+    .then((hash) => {
+      // new user details
+      const user = new User({
+        email,
+        username,
+        password: hash
+      });
+      // attempt to save user in database
+      user
+        .save()
+        // response returned after successfully saving user in database
+        .then(() => res.status(201).json({ code: 201, message: 'user successfully created' }))
+        .catch((err) => {
+          // in case of any error when saving user in database
+          // we channel the error to the error handler in app.js
+          next(err);
+        });
+    })
+    .catch((error) => {
+      // if an error is encountered hashing the password
+      // we channel the error to the error handler in app.js
+      next(error);
+    });
+};
+
+module.exports = {
+  signup
 };

--- a/src/backend/models/User.js
+++ b/src/backend/models/User.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+// specify attributes of a user and constraints on the attributes
+const userSchema = mongoose.Schema({
+  email: { type: String, required: true, unique: true },
+  username: { type: String, required: true, unique: true },
+  password: { type: String, required: true }
+});
+
+// this exports the defined User Model
+module.exports = mongoose.model('User', userSchema);

--- a/src/backend/routes/user.js
+++ b/src/backend/routes/user.js
@@ -1,8 +1,7 @@
 
 const router = require('express').Router();
-const { testEndpoint } = require('../controllers/user');
+const userRoutes = require('../controllers/user');
 
-// TODO: remove this, is just a test of the setup
-router.get('/test', testEndpoint);
+router.post('/', userRoutes.signup); // user signup route & logic
 
 module.exports = router;


### PR DESCRIPTION
## Description
Implemented user sign up functionality through POST /users endpoint.
Edited the `user.test.js` file to extract data object from axios requests response object.
As a result all response objects are now response.data.

No new dependencies are required for this change.

Fixes #5 

## How Has This Been Tested?
This has been tested by `user can register` test in `User` test suite.
The test mimics postman API testing application.
It sends a valid request to POST /users endpoint.
And asserts if the response body contains a success message.

## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added necessary inline code documentation
- [x] I have added tests that prove my fix is effective and that this feature works
- [x] New and existing unit tests pass locally with my changes
