### PR TITLE
feat(user): added ability for a user to delete their account

### DIFF
--- a/src/backend/__tests__/user.test.js
+++ b/src/backend/__tests__/user.test.js
@@ -41,7 +41,7 @@ describe('User', () => {
 
 
   // POST /users (register new user)
-  test.only('user can register', () => {
+  test('user can register', () => {
     // this expects global var resBody to have success message
     expect(resBody.message).toBe('user successfully created');
   });
@@ -66,13 +66,13 @@ describe('User', () => {
     });
 
     // POST /login
-    test.only('user can login', () => {
+    test('user can login', () => {
       // expects token not to be null
       expect(token).not.toBeNull();
     });
 
     // PUT /users/:id
-    test.only('user can update profile', (done) => {
+    test('user can update profile', (done) => {
       // given authenticated user
       // when they hit the endpoint PUT /users/:id
       axios
@@ -85,7 +85,7 @@ describe('User', () => {
           },
           {
             headers: {
-              authorization: `bearer ${token}`
+              authorization: token
             }
           }
         )
@@ -114,7 +114,7 @@ describe('User', () => {
           `/users/${authUserId}`, // authUserId is id of a logged in user
           {
             headers: {
-              authorization: `bearer ${token}`
+              authorization: token
             },
             data: {
               id: authUserId

--- a/src/backend/controllers/user.js
+++ b/src/backend/controllers/user.js
@@ -105,15 +105,12 @@ const updateUser = (req, res, next) => {
 
       User
         .updateOne({ _id: req.params.id }, user)
-        // eslint-disable-next-line arrow-body-style
-        .then(() => {
-          return res
-            .status(201)
-            .json({
-              message: 'user successfully updated',
-              code: 201
-            });
-        })
+        .then(() => res
+          .status(201)
+          .json({
+            message: 'user successfully updated',
+            code: 201
+          }))
         .catch((err) => {
           next(err); // channel error to error handler
         });
@@ -123,8 +120,23 @@ const updateUser = (req, res, next) => {
     });
 };
 
+const deleteUser = (req, res, next) => {
+  User
+    .deleteOne({ _id: req.params.id })
+    .then(() => res
+      .status(201)
+      .json({
+        message: 'user successfully deleted',
+        code: 201
+      }))
+    .catch((error) => {
+      next(error); // channel error to error handler in app.js
+    });
+};
+
 module.exports = {
   signup,
   login,
-  updateUser
+  updateUser,
+  deleteUser
 };

--- a/src/backend/middleware/auth.js
+++ b/src/backend/middleware/auth.js
@@ -1,0 +1,22 @@
+const jwt = require('jsonwebtoken');
+require('dotenv').config('../.env');
+
+// eslint-disable-next-line consistent-return
+module.exports = (req, res, next) => {
+  try {
+    const token = req.headers.authorization; // extract authorization header
+    const decodeToken = jwt.verify(token, process.env.TOKEN_SECRET); // decrypt token
+    const { id } = decodeToken; // extract payload data from decodedToken
+    if (req.params.id !== id) {
+      return res
+        .status(401)
+        .json({
+          code: 401,
+          message: 'unauthorized'
+        });
+    }
+    next(); // continue execution if user id matches id in token
+  } catch (error) {
+    next(error); // channel errors to logger & handler in app.js
+  }
+};

--- a/src/backend/routes/user.js
+++ b/src/backend/routes/user.js
@@ -1,9 +1,11 @@
 
 const router = require('express').Router();
 const userRoutes = require('../controllers/user');
+const auth = require('../middleware/auth');
 
 router.post('/', userRoutes.signup); // user signup route & logic
 router.post('/login', userRoutes.login); // user login route & logic
-router.put('/:id', userRoutes.updateUser); // user update route & logic
+router.put('/:id', auth, userRoutes.updateUser); // user update route & logic
+router.delete('/:id', auth, userRoutes.deleteUser); // delete user route & logic
 
 module.exports = router;


### PR DESCRIPTION

## Description
Added the ability for a user to delete their account.
Added auth middleware to PUT and DELETE routes for User.
This ensures only an authenticated user can update or delete their account.

Fixes #8 

## How Has This Been Tested?
This has been test by making requests to the DELETE /users/:id route and asserting that only authenticated user can delete their account.
PUT routes have been tested by sending requests from unauthenticated user and asserting that no update takes place.


## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added necessary inline code documentation
- [x] I have added tests that prove my fix is effective and that this feature works
- [x] New and existing unit tests pass locally with my changes
